### PR TITLE
Display app badge for due dailies

### DIFF
--- a/HabitRPG/HRPGAppDelegate.m
+++ b/HabitRPG/HRPGAppDelegate.m
@@ -106,7 +106,7 @@
     if(userInfo) {
         [self handlePushNotification:userInfo];
     }
-    
+
     return YES;
 }
 
@@ -344,7 +344,7 @@
 
 - (void)configureNotifications:(UIApplication *)application {
     if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
-        UIUserNotificationType types = UIUserNotificationTypeSound | UIUserNotificationTypeAlert;
+        UIUserNotificationType types = UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge;
 
         UIMutableUserNotificationAction *completeAction =
             [[UIMutableUserNotificationAction alloc] init];
@@ -376,7 +376,7 @@
         questInviteCategory.identifier = @"questInvitation";
         [questInviteCategory setActions:@[ acceptAction, rejectAction ]
                           forContext:UIUserNotificationActionContextDefault];
-        
+
         UIMutableUserNotificationAction *replyAction =
         [[UIMutableUserNotificationAction alloc] init];
         replyAction.identifier = @"replyAction";
@@ -391,7 +391,7 @@
         privateMessageCategory.identifier = @"newPM";
         [privateMessageCategory setActions:@[ replyAction ]
                           forContext:UIUserNotificationActionContextDefault];
-        
+
         UIUserNotificationSettings *settings =
             [UIUserNotificationSettings settingsForTypes:types
                                               categories:[NSSet setWithObjects:completeCategory, questInviteCategory, privateMessageCategory, nil]];

--- a/HabitRPG/HRPGAppDelegate.m
+++ b/HabitRPG/HRPGAppDelegate.m
@@ -84,6 +84,7 @@
 
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"dailyReminderActive"];
         [[NSUserDefaults standardUserDefaults] setValue:newDate forKey:@"dailyReminderTime"];
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"appBadgeActive"];
         [[UIApplication sharedApplication] cancelAllLocalNotifications];
         UILocalNotification *localNotification = [[UILocalNotification alloc] init];
         localNotification.fireDate = newDate;

--- a/HabitRPG/HRPGManager.h
+++ b/HabitRPG/HRPGManager.h
@@ -24,6 +24,7 @@
 
 @property(nonatomic, strong) NSManagedObjectContext *managedObjectContext;
 @property(nonatomic, strong) User *user;
+@property(nonatomic) BOOL *useAppBadge;
 
 - (void)loadObjectManager:(RKManagedObjectStore *)existingManagedObjectStore;
 
@@ -299,5 +300,7 @@
                     withExperienceDiff:(NSNumber *)expDiff
                           withGoldDiff:(NSNumber *)goldDiff
                          withMagicDiff:(NSNumber *)magicDiff;
+
+- (void)changeUseAppBadge:(BOOL *)useAppBadge;
 
 @end

--- a/HabitRPG/HRPGManager.m
+++ b/HabitRPG/HRPGManager.m
@@ -122,15 +122,15 @@ NSString *currentUser;
     NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
     NSString *CUSTOM_DOMAIN = info[@"CustomDomain"];
     NSString *DISABLE_SSL = info[@"DisableSSL"];
-    
+
     if (CUSTOM_DOMAIN.length == 0) {
         CUSTOM_DOMAIN = @"habitica.com/";
     }
-    
+
     if (![[CUSTOM_DOMAIN substringFromIndex: [CUSTOM_DOMAIN length] - 1]  isEqual: @"/"]) {
         CUSTOM_DOMAIN = [CUSTOM_DOMAIN stringByAppendingString:@"/"];
     }
-    
+
 
     if ([DISABLE_SSL isEqualToString:@"true"]) {
         ROOT_URL = [NSString stringWithFormat:@"http://%@", CUSTOM_DOMAIN];
@@ -143,8 +143,8 @@ NSString *currentUser;
 
     ROOT_URL = [ROOT_URL stringByAppendingString:@"api/v3/"];
 
-    
-    
+
+
     // Set the default store shared instance
     [RKManagedObjectStore setDefaultStore:managedObjectStore];
     RKObjectManager *objectManager =
@@ -403,7 +403,7 @@ NSString *currentUser;
                               keyPath:@"data"
                           statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
     [objectManager addResponseDescriptor:responseDescriptor];
-    
+
     responseDescriptor = [RKResponseDescriptor
                           responseDescriptorWithMapping:taskMapping
                           method:RKRequestMethodPOST
@@ -428,11 +428,11 @@ NSString *currentUser;
 
         return nil;
     }];
-    
+
     [objectManager addFetchRequestBlock:^NSFetchRequest *(NSURL *URL) {
         RKPathMatcher *pathMatcher =
         [RKPathMatcher pathMatcherWithPattern:@"content"];
-        
+
         NSDictionary *argsDict = nil;
         BOOL match = [pathMatcher matchesPath:[URL relativePath]
                          tokenizeQueryStrings:NO
@@ -442,7 +442,7 @@ NSString *currentUser;
             fetchRequest.predicate = [NSPredicate predicateWithFormat:@"type=='background'"];
             return fetchRequest;
         }
-        
+
         return nil;
     }];
 
@@ -455,7 +455,7 @@ NSString *currentUser;
                               parsedArguments:&argsDict];
         if (match) {
             NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Task"];
-            
+
             HRPGURLParser *parser = [[HRPGURLParser alloc] initWithURLString:[URL absoluteString]];
             NSString *typeQuery = [parser valueForVariable:@"type"];
             if (typeQuery) {
@@ -506,10 +506,10 @@ NSString *currentUser;
 
         return nil;
     }];
-    
+
     [objectManager addFetchRequestBlock:^NSFetchRequest *(NSURL *URL) {
         RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPattern:@"user"];
-        
+
         NSDictionary *argsDict = nil;
         BOOL match = [pathMatcher matchesPath:[URL relativePath]
                          tokenizeQueryStrings:NO
@@ -518,7 +518,7 @@ NSString *currentUser;
             NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"InboxMessage"];
             return fetchRequest;
         }
-        
+
         return nil;
     }];
 
@@ -540,10 +540,10 @@ NSString *currentUser;
 
         return nil;
     }];
-    
+
     [objectManager addFetchRequestBlock:^NSFetchRequest *(NSURL *URL) {
         RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPattern:@"groups/:id/members"];
-        
+
         NSDictionary *argsDict = nil;
         BOOL match = [pathMatcher matchesPath:[URL relativePath]
                          tokenizeQueryStrings:YES
@@ -553,13 +553,13 @@ NSString *currentUser;
             fetchRequest.predicate = [NSPredicate predicateWithFormat:@"partyID == %@", argsDict[@"id"]];
             return fetchRequest;
         }
-        
+
         return nil;
     }];
-    
+
     [objectManager addFetchRequestBlock:^NSFetchRequest *(NSURL *URL) {
         RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPattern:@"shops/:identifier"];
-        
+
         NSDictionary *argsDict = nil;
         BOOL match = [pathMatcher matchesPath:[URL relativePath]
                          tokenizeQueryStrings:YES
@@ -569,13 +569,13 @@ NSString *currentUser;
             fetchRequest.predicate = [NSPredicate predicateWithFormat:@"category.shop.identifier == %@", argsDict[@"identifier"]];
             return fetchRequest;
         }
-        
+
         return nil;
     }];
-    
+
     [objectManager addFetchRequestBlock:^NSFetchRequest *(NSURL *URL) {
         RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPattern:@"shops/:identifier"];
-        
+
         NSDictionary *argsDict = nil;
         BOOL match = [pathMatcher matchesPath:[URL relativePath]
                          tokenizeQueryStrings:YES
@@ -585,7 +585,7 @@ NSString *currentUser;
             fetchRequest.predicate = [NSPredicate predicateWithFormat:@"shop.identifier == %@", argsDict[@"identifier"]];
             return fetchRequest;
         }
-        
+
         return nil;
     }];
 
@@ -679,7 +679,7 @@ NSString *currentUser;
                           keyPath:nil
                           statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
     [objectManager addResponseDescriptor:responseDescriptor];
-    
+
     RKObjectMapping *feedMapping = [RKObjectMapping mappingForClass:[NSMutableDictionary class]];
     [feedMapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:nil toKeyPath:@"value"]];
     responseDescriptor = [RKResponseDescriptor
@@ -821,7 +821,7 @@ NSString *currentUser;
                                                               ]];
     [pushNotificationsMapping addAttributeMappingsFromDictionary:@{@"@parent.@parent._id" : @"userID"}];
     [preferencesMapping addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:@"pushNotifications" toKeyPath:@"pushNotifications" withMapping:pushNotificationsMapping]];
-    
+
     RKEntityMapping *flagsMapping =
         [RKEntityMapping mappingForEntityForName:@"Flags" inManagedObjectStore:managedObjectStore];
     [flagsMapping addAttributeMappingsFromDictionary:@{
@@ -952,7 +952,7 @@ NSString *currentUser;
     [taskOrderMapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:nil toKeyPath:@"id"]];
     [taskOrderMapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"@metadata.mapping.collectionIndex" toKeyPath:@"order"]];
     taskOrderMapping.identificationAttributes = @[ @"id" ];
-    
+
     responseDescriptor = [RKResponseDescriptor
                           responseDescriptorWithMapping:taskOrderMapping
                           method:RKRequestMethodAny
@@ -974,7 +974,7 @@ NSString *currentUser;
                           keyPath:@"data.tasksOrder.dailys"
                           statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
     [objectManager addResponseDescriptor:responseDescriptor];
-    
+
     RKEntityMapping *inboxMessageMapping = [RKEntityMapping mappingForEntityForName:@"InboxMessage"
                                                        inManagedObjectStore:managedObjectStore];
     [inboxMessageMapping setForceCollectionMapping:YES];
@@ -996,7 +996,7 @@ NSString *currentUser;
                                        relationshipMappingFromKeyPath:@"inbox.messages"
                                        toKeyPath:@"inboxMessages"
                                        withMapping:inboxMessageMapping]];
-    
+
     RKEntityMapping *pushDeviceMapping = [RKEntityMapping mappingForEntityForName:@"PushDevice"
                                                                inManagedObjectStore:managedObjectStore];
     [pushDeviceMapping setForceCollectionMapping:YES];
@@ -1009,7 +1009,7 @@ NSString *currentUser;
                                        relationshipMappingFromKeyPath:@"pushDevices"
                                        toKeyPath:@"pushDevices"
                                        withMapping:pushDeviceMapping]];
-    
+
     responseDescriptor = [RKResponseDescriptor
         responseDescriptorWithMapping:entityMapping
                                method:RKRequestMethodPOST
@@ -1873,7 +1873,7 @@ NSString *currentUser;
                                                      keyPath:nil
                                                      statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
     [objectManager addResponseDescriptor:messageResponseDescriptor];
-    
+
     RKEntityMapping *shopMapping = [RKEntityMapping mappingForEntityForName:@"Shop"
                                                        inManagedObjectStore:managedObjectStore];
     [shopMapping addAttributeMappingsFromArray:@[@"text", @"identifier", @"notes", @"imageName", @"purchaseAll"]];
@@ -1903,8 +1903,8 @@ NSString *currentUser;
                           keyPath:@"data"
                           statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
     [objectManager addResponseDescriptor:responseDescriptor];
-    
-    
+
+
     [[RKObjectManager sharedManager].HTTPClient setDefaultHeader:@"x-client" value:@"habitica-ios"];
 
     [self setCredentials];
@@ -2170,7 +2170,7 @@ NSString *currentUser;
 
 - (void)fetchCompletedTasks:(void (^)())successBlock onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager]
      getObjectsAtPath:@"tasks/user?type=completedTodos"
      parameters:nil
@@ -2739,7 +2739,7 @@ NSString *currentUser;
 
 - (void)createTasks:(NSArray *)tasks onSuccess:(void (^)())successBlock onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] postObject:nil
                                            path:@"tasks/user"
                                      parameters:tasks
@@ -3241,7 +3241,7 @@ NSString *currentUser;
                 Gear *gear = (Gear *)reward;
                 gear.owned = YES;
             }
-            
+
             if (response.armoireType) {
                 HRPGResponseMessage *message = [mappingResult dictionary][[NSNull null]];
                 [self displayArmoireNotification:response.armoireType
@@ -3602,7 +3602,7 @@ NSString *currentUser;
 
 - (void)markInboxSeen:(void (^)())successBlock onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] postObject:nil
                                            path:@"user/mark-pms-read"
                                      parameters:nil
@@ -4089,7 +4089,7 @@ NSString *currentUser;
 
 - (void)privateMessage:(InboxMessage *)message toUserWithID:(NSString *)userID onSuccess:(void (^)())successBlock onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] postObject:nil
                                            path:@"members/send-private-message"
                                      parameters:@{
@@ -4155,7 +4155,7 @@ NSString *currentUser;
             onSuccess:(void (^)())successBlock
               onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] deleteObject:message
                                              path:[NSString stringWithFormat:@"user/messages/%@", message.id]
                                        parameters:nil
@@ -4405,7 +4405,7 @@ NSString *currentUser;
            onSuccess:(void (^)())successBlock
              onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] postObject:nil
                                            path:[NSString stringWithFormat:@"user/purchase-hourglass/%@/%@", item.purchaseType, item.key]
                                      parameters:nil
@@ -4444,7 +4444,7 @@ NSString *currentUser;
                     onSuccess:(void (^)())successBlock
                       onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] postObject:nil
                                            path:[NSString stringWithFormat:@"user/buy-mystery-set/%@", key]
                                      parameters:nil
@@ -4483,7 +4483,7 @@ NSString *currentUser;
                     onSuccess:(void (^)())successBlock
                       onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] postObject:nil
                                            path:[NSString stringWithFormat:@"user/buy-quest/%@", item.key]
                                      parameters:nil
@@ -4522,7 +4522,7 @@ NSString *currentUser;
            onSuccess:(void (^)())successBlock
              onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     [[RKObjectManager sharedManager] postObject:nil
                                            path:@"user/push-devices"
                                      parameters:@{
@@ -4549,11 +4549,11 @@ NSString *currentUser;
 - (void)removePushDevice:(void (^)())successBlock
               onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     if ([defaults stringForKey:@"PushNotificationDeviceToken"]) {
         NSString *token = [defaults stringForKey:@"PushNotificationDeviceToken"];
         [defaults removeObjectForKey:@"PushNotificationDeviceToken"];
-    
+
         [[RKObjectManager sharedManager] deleteObject:nil
                                            path:[@"user/push-devices/" stringByAppendingString:token]
                                      parameters:nil
@@ -4580,7 +4580,7 @@ NSString *currentUser;
 
 - (void)fetchShopInventory:(NSString *)shopInventory onSuccess:(void (^)())successBlock onError:(void (^)())errorBlock {
     [self.networkIndicatorController beginNetworking];
-    
+
     NSString *url = @"shops/";
     if ([shopInventory isEqualToString:MarketKey]) {
         url = [url stringByAppendingString:@"market"];
@@ -4751,18 +4751,18 @@ NSString *currentUser;
 
 - (void)displayLevelUpNotification {
     [self fetchUser:nil onError:nil];
-    
+
     if ([self.user.level integerValue] == 10 && ![self.user.preferences.disableClass boolValue]) {
         HRPGAppDelegate *del = (HRPGAppDelegate *)[UIApplication sharedApplication].delegate;
         UIViewController *activeViewController = del.window.rootViewController;UINavigationController *selectClassNavigationController =
         [del.window.rootViewController.storyboard
          instantiateViewControllerWithIdentifier:@"SelectClassNavigationController"];
         selectClassNavigationController.modalPresentationStyle = UIModalPresentationFullScreen;
-        
+
         [activeViewController presentViewController:selectClassNavigationController
                                            animated:YES
                                          completion:^(){
-                                             
+
                                          }];
     } else {
         NSArray *nibViews =
@@ -4800,14 +4800,14 @@ NSString *currentUser;
              withSourceView:nil];
         };
         [overlayView sizeToFit];
-        
+
         KLCPopup *popup = [KLCPopup popupWithContentView:overlayView
                                                 showType:KLCPopupShowTypeBounceIn
                                              dismissType:KLCPopupDismissTypeBounceOut
                                                 maskType:KLCPopupMaskTypeDimmed
                                 dismissOnBackgroundTouch:YES
                                    dismissOnContentTouch:NO];
-        
+
         [popup show];
     }
 }
@@ -4902,7 +4902,7 @@ NSString *currentUser;
                                          }];
          }
            onError:^(){
-               
+
            }];
     } else {
         UIColor *notificationColor = [UIColor blue10];
@@ -5036,6 +5036,10 @@ NSString *currentUser;
              onSuccess:(void (^)())successBlock {
     [[YYImageCache sharedCache] setImage:image forKey:imageName];
     successBlock();
+}
+
+- (void)changeUseAppBadge:(BOOL *)newUseAppBadge {
+    self.useAppBadge = newUseAppBadge;
 }
 
 @end

--- a/HabitRPG/HRPGManager.m
+++ b/HabitRPG/HRPGManager.m
@@ -122,10 +122,15 @@ NSString *currentUser;
     NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
     NSString *CUSTOM_DOMAIN = info[@"CustomDomain"];
     NSString *DISABLE_SSL = info[@"DisableSSL"];
-
+    
     if (CUSTOM_DOMAIN.length == 0) {
         CUSTOM_DOMAIN = @"habitica.com/";
     }
+    
+    if (![[CUSTOM_DOMAIN substringFromIndex: [CUSTOM_DOMAIN length] - 1]  isEqual: @"/"]) {
+        CUSTOM_DOMAIN = [CUSTOM_DOMAIN stringByAppendingString:@"/"];
+    }
+    
 
     if ([DISABLE_SSL isEqualToString:@"true"]) {
         ROOT_URL = [NSString stringWithFormat:@"http://%@", CUSTOM_DOMAIN];

--- a/HabitRPG/TabBarController/HRPGTabBarController.m
+++ b/HabitRPG/TabBarController/HRPGTabBarController.m
@@ -161,6 +161,8 @@
 - (void)updateDailyBadge {
     UITabBarItem *dailyItem = self.tabBar.items[1];
     NSInteger badgeCount = 0;
+    NSInteger appBadgeCount = 0;
+    
     for (Task *task in self.fetchedResultsController.fetchedObjects) {
         if ([task dueTodayWithOffset:[[self.sharedManager getUser]
                                              .preferences.dayStart integerValue]]) {
@@ -172,7 +174,12 @@
     } else {
         dailyItem.badgeValue = nil;
     }
-    [UIApplication sharedApplication].applicationIconBadgeNumber = badgeCount;
+
+    if (self.sharedManager.useAppBadge) {
+      appBadgeCount = badgeCount;
+    }
+
+    [UIApplication sharedApplication].applicationIconBadgeNumber = appBadgeCount;
 }
 
 - (void)controller:(NSFetchedResultsController *)controller

--- a/HabitRPG/TabBarController/HRPGTabBarController.m
+++ b/HabitRPG/TabBarController/HRPGTabBarController.m
@@ -172,6 +172,7 @@
     } else {
         dailyItem.badgeValue = nil;
     }
+    [UIApplication sharedApplication].applicationIconBadgeNumber = badgeCount;
 }
 
 - (void)controller:(NSFetchedResultsController *)controller

--- a/HabitRPG/TableViewController/HRPGSettingsViewController.m
+++ b/HabitRPG/TableViewController/HRPGSettingsViewController.m
@@ -153,7 +153,7 @@ User *user;
     if ([defaults boolForKey:@"appBadgeActive"]) {
       row.value = @YES;
     }
-    
+
     section = [XLFormSectionDescriptor formSectionWithTitle:NSLocalizedString(@"Day Start", nil)];
     [formDescriptor addFormSection:section];
     row =

--- a/HabitRPG/TableViewController/HRPGSettingsViewController.m
+++ b/HabitRPG/TableViewController/HRPGSettingsViewController.m
@@ -20,6 +20,7 @@
 @property HRPGManager *sharedManager;
 @property NSManagedObjectContext *managedObjectContext;
 @property XLFormSectionDescriptor *reminderSection;
+@property XLFormSectionDescriptor *appBadgeSection;
 @property XLFormRowDescriptor *pushNotificationRow;
 @end
 
@@ -141,6 +142,18 @@ User *user;
         [self showDatePicker];
     }
 
+    self.appBadgeSection =
+      [XLFormSectionDescriptor formSectionWithTitle:NSLocalizedString(@"App Badge Notification", nil)];
+    [formDescriptor addFormSection:self.appBadgeSection];
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:@"useAppBadge"
+                                             rowType:XLFormRowDescriptorTypeBooleanSwitch
+                                               title:NSLocalizedString(@"App badge Notification", nil)];
+    [row.cellConfig setObject:[UIColor purple400] forKey:@"self.tintColor"];
+    [self.appBadgeSection addFormRow:row];
+    if ([defaults boolForKey:@"appBadgeActive"]) {
+      row.value = @YES;
+    }
+    
     section = [XLFormSectionDescriptor formSectionWithTitle:NSLocalizedString(@"Day Start", nil)];
     [formDescriptor addFormSection:section];
     row =
@@ -190,13 +203,13 @@ User *user;
     self.pushNotificationRow.valueTransformer = [HRPGPushNotificationSettingValueTransformer class];
     [row.cellConfig setObject:[UIColor purple400] forKey:@"self.tintColor"];
     [section addFormRow:self.pushNotificationRow];
-    
+
     row = [XLFormRowDescriptor formRowDescriptorWithTag:@"disableInbox" rowType:XLFormRowDescriptorTypeBooleanSwitch title:NSLocalizedString(@"Disable Private Messages", nil)];
     row.value = [XLFormOptionsObject formOptionsOptionForValue:user.inboxOptOut fromOptions:nil];
     [row.cellConfig setObject:[UIColor purple400] forKey:@"self.tintColor"];
     [section addFormRow:row];
-    
-    
+
+
     section = [XLFormSectionDescriptor formSectionWithTitle:NSLocalizedString(@"Maintenance", nil)];
     [formDescriptor addFormSection:section];
 
@@ -265,7 +278,7 @@ User *user;
                                                                      displayText:NSLocalizedString(@"Invited To Quest", nil)],
                                  ];
     self.pushNotificationRow.selectorOptions = selectorOptions;
-    
+
     NSMutableArray *valueOptions = [NSMutableArray arrayWithCapacity:8];
     if ([user.preferences.pushNotifications.wonChallenge boolValue]) {
         [valueOptions addObject:selectorOptions[0]];
@@ -308,7 +321,7 @@ User *user;
         [defaults setObject:@"" forKey:@"dailyFilter"];
         [defaults setObject:@"" forKey:@"todoFilter"];
         [weakSelf.sharedManager clearLoginCredentials];
-        
+
         [weakSelf.sharedManager
          resetSavedDatabase:YES
          onComplete:^() {
@@ -325,7 +338,7 @@ User *user;
                        }];
          }];
     };
-    
+
     if ([defaults stringForKey:@"PushNotificationDeviceToken"]) {
         [self.sharedManager removePushDevice:^{
             logoutBlock();
@@ -465,7 +478,7 @@ User *user;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
-    if (section == 2) {
+    if (section == 3) {
         return NSLocalizedString(@"Habitica defaults to check and reset your Dailies at midnight "
                                  @"in your own time zone each day. You can customize that time "
                                  @"here.",

--- a/HabitRPG/TableViewController/HRPGSettingsViewController.m
+++ b/HabitRPG/TableViewController/HRPGSettingsViewController.m
@@ -526,6 +526,9 @@ User *user;
 
 - (void)changeAppBadgeSettings:(BOOL *)newValue {
     [self.sharedManager changeUseAppBadge: newValue];
+    if (!newValue) {
+      [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
+    }
 }
 
 @end

--- a/HabitRPG/TableViewController/HRPGSettingsViewController.m
+++ b/HabitRPG/TableViewController/HRPGSettingsViewController.m
@@ -433,6 +433,9 @@ User *user;
             [self hideDatePicker];
             [[UIApplication sharedApplication] cancelAllLocalNotifications];
         }
+    } else if ([rowDescriptor.tag isEqualToString:@"useAppBadge"]) {
+        [self changeAppBadgeSettings:[newValue boolValue]];
+        [defaults setBool:[newValue boolValue] forKey:@"appBadgeActive"];
     } else if ([rowDescriptor.tag isEqualToString:@"reminderDate"]) {
         [self reminderTimeChanged:[rowDescriptor.value valueData]];
     } else if ([rowDescriptor.tag isEqualToString:@"dayStart"]) {
@@ -519,6 +522,10 @@ User *user;
                                      @"preferences.pushNotifications.wonChallenge": newValues.wonChallenge ? newValues.wonChallenge : @NO,
                                      @"preferences.pushNotifications.unsubscribeFromAll": newValues.unsubscribeFromAll ? newValues.unsubscribeFromAll : @NO
                                      }onSuccess:nil onError:nil];
+}
+
+- (void)changeAppBadgeSettings:(BOOL *)newValue {
+    [self.sharedManager changeUseAppBadge: newValue];
 }
 
 @end

--- a/HabitRPG/TableViewController/HRPGSettingsViewController.m
+++ b/HabitRPG/TableViewController/HRPGSettingsViewController.m
@@ -143,11 +143,11 @@ User *user;
     }
 
     self.appBadgeSection =
-      [XLFormSectionDescriptor formSectionWithTitle:NSLocalizedString(@"App Badge Notification", nil)];
+      [XLFormSectionDescriptor formSectionWithTitle:NSLocalizedString(@"Notification Badge", nil)];
     [formDescriptor addFormSection:self.appBadgeSection];
     row = [XLFormRowDescriptor formRowDescriptorWithTag:@"useAppBadge"
                                              rowType:XLFormRowDescriptorTypeBooleanSwitch
-                                               title:NSLocalizedString(@"App badge Notification", nil)];
+                                               title:NSLocalizedString(@"Display Notification Badge", nil)];
     [row.cellConfig setObject:[UIColor purple400] forKey:@"self.tintColor"];
     [self.appBadgeSection addFormRow:row];
     if ([defaults boolForKey:@"appBadgeActive"]) {


### PR DESCRIPTION
Resolves #122 

Does:
- add a toggle to the settings menu to display badge notifications
- display the same number on the app badge as the dailies tab, if setting is on
- not display anything if setting is off
- badge disappears when setting is toggled off

Does NOT:
- update with background refresh. App badge update only occurs when the dailies tab badge updates
- appear when setting is toggled on. Currently a single daily needs to be toggled for the app badge to appear.

my Habitica User-ID: a02008ea-4101-4a98-9c82-30f253f34405
