### PR TITLE
update json gem dep for sierra

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.0.2)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     minitest (5.9.0)
     molinillo (0.5.6)
     nanaimo (0.2.3)
@@ -82,4 +82,4 @@ DEPENDENCIES
   cocoapods-keys (>= 1.7.0)
 
 BUNDLED WITH
-   1.12.5
+   1.14.6


### PR DESCRIPTION
On macOS Sierra, I keep getting an error when running `bundle install` about the json gem. Running `bundle update json` fixes the issue.
my Habitica User-ID: 26d0ea00-bad1-4ec2-8531-918d522e6e47
